### PR TITLE
Add an option (on by default) to strip audio files

### DIFF
--- a/cmd/kepubify/kepubify.go
+++ b/cmd/kepubify/kepubify.go
@@ -52,6 +52,7 @@ func main() {
 	noadddummytitlepage := pflag.Bool("no-add-dummy-titlepage", false, "Force-disables the dummy titlepage")
 	replace := pflag.StringArrayP("replace", "r", nil, "Find and replace on all html files (repeat any number of times) (format: find|replace)")
 	charset := pflag.String("charset", "utf-8", "Override the HTML charset (use \"auto\" to detect it from the content)")
+	leaveaudio := pflag.Bool("leave-audio", false, "Leave audio files in the book")
 
 	for _, flag := range []string{"smarten-punctuation", "css", "hyphenate", "no-hyphenate", "fullscreen-reading-fixes", "add-dummy-titlepage", "no-add-dummy-titlepage", "replace", "charset"} {
 		pflag.CommandLine.SetAnnotation(flag, "category", []string{"3.Conversion Options"})
@@ -107,6 +108,9 @@ func main() {
 		opts = append(opts, kepub.ConverterOptionDummyTitlepage(true))
 	} else if *noadddummytitlepage {
 		opts = append(opts, kepub.ConverterOptionDummyTitlepage(false))
+	}
+	if *leaveaudio {
+		opts = append(opts, kepub.ConverterOptionLeaveAudio(true))
 	}
 	for _, r := range *replace {
 		spl := strings.SplitN(r, "|", 2)

--- a/kepub/convert.go
+++ b/kepub/convert.go
@@ -137,6 +137,14 @@ func (c *Converter) Convert(ctx context.Context, w io.Writer, r fs.FS) error {
 		}
 	}
 
+	if !c.leaveAudio {
+		for i, f := range files {
+			if c.IsAudioFile(f.Name) {
+				fileAct[i] = FileActionIgnore
+			}
+		}
+	}
+
 	// we'll manually create the mimetype file
 	if i, ok := fileIdx["mimetype"]; ok {
 		fileAct[i] = FileActionIgnore

--- a/kepub/kepub.go
+++ b/kepub/kepub.go
@@ -25,6 +25,9 @@ type Converter struct {
 
 	// charset override
 	charset string // "auto" for auto-detection
+
+	// do not strip audio files (audiobook data)
+	leaveAudio bool
 }
 
 // ConverterOption configures a Converter.
@@ -42,6 +45,13 @@ func NewConverterWithOptions(opts ...ConverterOption) *Converter {
 		f(c)
 	}
 	return c
+}
+
+// ConverterOptionLeaveAudio enables or disables leaving audio files in the book.
+func ConverterOptionLeaveAudio(leave bool) ConverterOption {
+	return func(c *Converter) {
+		c.leaveAudio = leave
+	}
 }
 
 // ConverterOptionSmartypants enables smart punctuation.

--- a/kepub/transform.go
+++ b/kepub/transform.go
@@ -50,6 +50,16 @@ func (c *Converter) TransformFileFilter(fn string) bool {
 	return false
 }
 
+func (c *Converter) IsAudioFile(fn string) bool {
+	switch path.Ext(fn) {
+	case ".mp3", ".m4a", ".m4b", ".m4p", ".m4r", ".m4v", ".mp4", ".aac", ".flac", ".ogg", ".oga", ".opus", ".webm", ".wav":
+		return true
+	case ".smil": // The media overlay
+		return true
+	}
+	return false
+}
+
 // TransformOPF transforms the OPF document for a KEPUB.
 //
 //  * [mandatory] add the cover-image property to the cover.


### PR DESCRIPTION
Kobo doesn't support audio files or audio overlays in EPUBs, and they blow up the file sizes tremendously. Strip them by default.