### PR TITLE
cmd/seriesmeta: Add Unicode normalization for book IDs

### DIFF
--- a/cmd/seriesmeta/seriesmeta.go
+++ b/cmd/seriesmeta/seriesmeta.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/pgaskin/koboutils/v2/kobo"
 	"github.com/spf13/pflag"
+	"golang.org/x/text/unicode/norm"
 )
 
 var version = "dev"
@@ -301,7 +302,9 @@ func (k *Kobo) UpdateSeries(log func(filename string, i, total int, series strin
 
 		if _, err := tx.Exec(
 			"INSERT OR REPLACE INTO _seriesmeta (ImageId, Series, SeriesNumber) VALUES (?, ?, ?)",
-			kobo.ContentIDToImageID(kobo.PathToContentID(relEpub)),
+			// Normalize the ID to NFC since Kobo runs Linux, meaning database entries use NFC as well.
+			// Helps with Unicode file names since without this SQLite cannot match values as expected.
+			norm.NFC.String(kobo.ContentIDToImageID(kobo.PathToContentID(relEpub))),
 			sql.NullString{String: series, Valid: len(series) > 0},
 			sql.NullString{String: strconv.FormatFloat(index, 'f', -1, 64), Valid: index > 0},
 		); err != nil {


### PR DESCRIPTION
The `_seriesmeta` trigger searches the `content` table for a book with the same ID as the inserted one.
```sql
SELECT COUNT() FROM content WHERE ImageId = new.ImageId
```
It works fine with ASCII IDs (which are kinda file paths BTW). However, when calling `seriesmeta` on macOS with Unicode file names being involved, it doesn’t work. This happens because IDs at `content` are NFC-normalized when macOS returns file paths as NFD-normalized strings. As an example (using Python):
```pycon
>>> value_content = "file____mnt_onboard_Books_Сапковский__Час_презрения_kepub_epub"
>>> value_series = "file____mnt_onboard_Books_Сапковский__Час_презрения_kepub_epub"

>>> value_content == value_series
False
>>> unicodedata.is_normalized("NFC", value_content)
True
>>> unicodedata.is_normalized("NFC", value_series)
False
>>> unicodedata.is_normalized("NFD", value_content)
False
>>> unicodedata.is_normalized("NFD", value_series)
True
```
In other words, visually values might look the same but without the normalization the SQLite comparison will not work. 